### PR TITLE
Refactored where types are imported from and how they are referenced

### DIFF
--- a/create-release-tag.sh
+++ b/create-release-tag.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+PACKAGE_VERSION=$(cat config.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g')
+PACKAGE_VERSION="${PACKAGE_VERSION:1}"
+
+git flow release start $PACKAGE_VERSION
+
+./changelog.sh
+git add CHANGELOG.md
+
+git commit -m "docs(changelog): \`CHANGELOG\` for \`$PACKAGE_VERSION\` release."
+
+git push --set-upstream origin release/$PACKAGE_VERSION
+
+# git flow release finish -m "$PACKAGE_VERSION release" -p $PACKAGE_VERSION
+# git push origin --tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrange/amqp-message-bus",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -396,12 +396,12 @@
       }
     },
     "@es-joy/jsdoccomment": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.7.tgz",
-      "integrity": "sha512-aNKZEoMESDzOBjKxCWrFuG50mcpMeKVBnBNko4+IZZ5t9zXYs8GT1KB0ZaOq1YUsKumDRc6YII/TQm309MJ0KQ==",
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.8.tgz",
+      "integrity": "sha512-3P1JiGL4xaR9PoTKUHa2N/LKwa2/eUdRqGwijMWWgBqbFEqJUVpmaOi2TcjcemrsRMgFLBzQCK4ToPhrSVDiFQ==",
       "dev": true,
       "requires": {
-        "comment-parser": "1.2.3",
+        "comment-parser": "1.2.4",
         "esquery": "^1.4.0",
         "jsdoc-type-pratt-parser": "1.1.1"
       }
@@ -635,10 +635,9 @@
       "dev": true
     },
     "@types/amqplib": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.8.1.tgz",
-      "integrity": "sha512-8dCjF+dHZ8Y6JOoHD1BMnxP0quAncvZq4wA/lS072NjX9vIzVRSMcmfKy2Os8ZQ8VWWp74MD09GMbVbKS6/Fxw==",
-      "dev": true,
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.8.2.tgz",
+      "integrity": "sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==",
       "requires": {
         "@types/bluebird": "*",
         "@types/node": "*"
@@ -647,8 +646,7 @@
     "@types/bluebird": {
       "version": "3.5.36",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
-      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
-      "dev": true
+      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q=="
     },
     "@types/chai": {
       "version": "4.2.21",
@@ -662,6 +660,12 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
@@ -669,10 +673,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
-      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
-      "dev": true
+      "version": "16.7.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz",
+      "integrity": "sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -696,13 +699,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.2.tgz",
-      "integrity": "sha512-x4EMgn4BTfVd9+Z+r+6rmWxoAzBaapt4QFqE+d8L8sUtYZYLDTK6VG/y/SMMWA5t1/BVU5Kf+20rX4PtWzUYZg==",
+      "version": "4.29.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.3.tgz",
+      "integrity": "sha512-tBgfA3K/3TsZY46ROGvoRxQr1wBkclbVqRQep97MjVHJzcRBURRY3sNFqLk0/Xr//BY5hM9H2p/kp+6qim85SA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.29.2",
-        "@typescript-eslint/scope-manager": "4.29.2",
+        "@typescript-eslint/experimental-utils": "4.29.3",
+        "@typescript-eslint/scope-manager": "4.29.3",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -710,6 +713,61 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "4.29.3",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.3.tgz",
+          "integrity": "sha512-ffIvbytTVWz+3keg+Sy94FG1QeOvmV9dP2YSdLFHw/ieLXWCa3U1TYu8IRCOpMv2/SPS8XqhM1+ou1YHsdzKrg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.7",
+            "@typescript-eslint/scope-manager": "4.29.3",
+            "@typescript-eslint/types": "4.29.3",
+            "@typescript-eslint/typescript-estree": "4.29.3",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "4.29.3",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.3.tgz",
+          "integrity": "sha512-x+w8BLXO7iWPkG5mEy9bA1iFRnk36p/goVlYobVWHyDw69YmaH9q6eA+Fgl7kYHmFvWlebUTUfhtIg4zbbl8PA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.29.3",
+            "@typescript-eslint/visitor-keys": "4.29.3"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.29.3",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.3.tgz",
+          "integrity": "sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.29.3",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.3.tgz",
+          "integrity": "sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.29.3",
+            "@typescript-eslint/visitor-keys": "4.29.3",
+            "debug": "^4.3.1",
+            "globby": "^11.0.3",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.29.3",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.3.tgz",
+          "integrity": "sha512-MGGfJvXT4asUTeVs0Q2m+sY63UsfnA+C/FDgBKV3itLBmM9H0u+URcneePtkd0at1YELmZK6HSolCqM4Fzs6yA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.29.3",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -742,17 +800,58 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.2.tgz",
-      "integrity": "sha512-WQ6BPf+lNuwteUuyk1jD/aHKqMQ9jrdCn7Gxt9vvBnzbpj7aWEf+aZsJ1zvTjx5zFxGCt000lsbD9tQPEL8u6g==",
+      "version": "4.29.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.3.tgz",
+      "integrity": "sha512-jrHOV5g2u8ROghmspKoW7pN8T/qUzk0+DITun0MELptvngtMrwUJ1tv5zMI04CYVEUsSrN4jV7AKSv+I0y0EfQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.29.2",
-        "@typescript-eslint/types": "4.29.2",
-        "@typescript-eslint/typescript-estree": "4.29.2",
+        "@typescript-eslint/scope-manager": "4.29.3",
+        "@typescript-eslint/types": "4.29.3",
+        "@typescript-eslint/typescript-estree": "4.29.3",
         "debug": "^4.3.1"
       },
       "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "4.29.3",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.3.tgz",
+          "integrity": "sha512-x+w8BLXO7iWPkG5mEy9bA1iFRnk36p/goVlYobVWHyDw69YmaH9q6eA+Fgl7kYHmFvWlebUTUfhtIg4zbbl8PA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.29.3",
+            "@typescript-eslint/visitor-keys": "4.29.3"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.29.3",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.3.tgz",
+          "integrity": "sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.29.3",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.3.tgz",
+          "integrity": "sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.29.3",
+            "@typescript-eslint/visitor-keys": "4.29.3",
+            "debug": "^4.3.1",
+            "globby": "^11.0.3",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.29.3",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.3.tgz",
+          "integrity": "sha512-MGGfJvXT4asUTeVs0Q2m+sY63UsfnA+C/FDgBKV3itLBmM9H0u+URcneePtkd0at1YELmZK6HSolCqM4Fzs6yA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.29.3",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -1268,9 +1367,9 @@
       "dev": true
     },
     "comment-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.3.tgz",
-      "integrity": "sha512-vnqDwBSXSsdAkGS5NjwMIPelE47q+UkEgWKHvCDNhVIIaQSUFY6sNnEYGzdoPGMdpV+7KR3ZkRd7oyWIjtuvJg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
+      "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
       "dev": true
     },
     "commondir": {
@@ -1666,26 +1765,26 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.0.tgz",
-      "integrity": "sha512-Kc6xqT9hiYi2cgybOc0I2vC9OgAYga5o/rAFinam/yF/t5uBqxQbauNPMC6fgb640T/89P0gFoO27FOilJ/Cqg==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
+      "integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.5",
+        "eslint-import-resolver-node": "^0.3.6",
         "eslint-module-utils": "^2.6.2",
         "find-up": "^2.0.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.4.0",
+        "is-core-module": "^2.6.0",
         "minimatch": "^3.0.4",
-        "object.values": "^1.1.3",
+        "object.values": "^1.1.4",
         "pkg-up": "^2.0.0",
         "read-pkg-up": "^3.0.0",
         "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.9.0"
+        "tsconfig-paths": "^3.11.0"
       },
       "dependencies": {
         "doctrine": {
@@ -1696,17 +1795,26 @@
           "requires": {
             "esutils": "^2.0.2"
           }
+        },
+        "is-core-module": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+          "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
         }
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "36.0.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.7.tgz",
-      "integrity": "sha512-x73l/WCRQ1qCjLq46Ca7csuGd5o3y3vbJIa3cktg11tdf3UZleBdIXKN9Cf0xjs3tXYPEy2SoNXowT8ydnjNDQ==",
+      "version": "36.0.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.8.tgz",
+      "integrity": "sha512-brNjHvRuBy5CaV01mSp6WljrO/T8fHNj0DXG38odOGDnhI7HdcbLKX7DpSvg2Rfcifwh8GlnNFzx13sI05t3bg==",
       "dev": true,
       "requires": {
-        "@es-joy/jsdoccomment": "0.10.7",
-        "comment-parser": "1.2.3",
+        "@es-joy/jsdoccomment": "0.10.8",
+        "comment-parser": "1.2.4",
         "debug": "^4.3.2",
         "esquery": "^1.4.0",
         "jsdoc-type-pratt-parser": "^1.1.1",
@@ -2961,9 +3069,9 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -4127,9 +4235,9 @@
       }
     },
     "ts-node": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.0.tgz",
-      "integrity": "sha512-FstYHtQz6isj8rBtYMN4bZdnXN1vq4HCbqn9vdNQcInRqtB86PePJQIxE6es0PhxKWhj2PHuwbG40H+bxkZPmg==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
+      "integrity": "sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "0.6.1",
@@ -4161,14 +4269,26 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
-      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
+      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
       "dev": true,
       "requires": {
-        "json5": "^2.2.0",
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
       }
     },
     "tslib": {
@@ -4234,9 +4354,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrange/amqp-message-bus",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Message bus based on amqplib",
   "main": "dist/index.js",
   "scripts": {
@@ -26,30 +26,31 @@
   "homepage": "https://github.com/0v3rst33r/amqp-message-bus#readme",
   "devDependencies": {
     "@inrange/auto-changelog": "2.4.0",
-    "@types/amqplib": "0.8.1",
     "@types/chai": "4.2.21",
     "@types/mocha": "9.0.0",
-    "@typescript-eslint/eslint-plugin": "4.29.2",
-    "@typescript-eslint/parser": "4.29.2",
+    "@types/node": "16.7.6",
+    "@typescript-eslint/eslint-plugin": "4.29.3",
+    "@typescript-eslint/parser": "4.29.3",
     "chai": "4.3.4",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-etc": "1.5.4",
-    "eslint-plugin-import": "2.24.0",
-    "eslint-plugin-jsdoc": "36.0.7",
+    "eslint-plugin-import": "2.24.2",
+    "eslint-plugin-jsdoc": "36.0.8",
     "eslint-plugin-no-null": "1.0.2",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-sonarjs": "0.10.0",
     "eslint-plugin-unicorn": "35.0.0",
-    "mocha": "9.0.3",
+    "mocha": "9.1.1",
     "nyc": "15.1.0",
     "prettier": "2.3.2",
     "reflect-metadata": "0.1.13",
     "rimraf": "3.0.2",
-    "ts-node": "10.2.0",
-    "typescript": "4.3.5"
+    "ts-node": "10.2.1",
+    "typescript": "4.4.2"
   },
   "dependencies": {
+    "@types/amqplib": "0.8.2",
     "amqplib": "0.8.0",
     "log4js": "6.3.0",
     "rxjs": "7.3.0"

--- a/src/amqp-message-bus.ts
+++ b/src/amqp-message-bus.ts
@@ -1,9 +1,8 @@
-import * as amqp from 'amqplib/callback_api';
-
 import * as messageBus from './index';
 import { catchError, map } from 'rxjs/operators';
 import { Subject, of } from 'rxjs';
 import { logUtil } from './util/log-util';
+import { Channel, connect, Connection } from 'amqplib/callback_api';
 
 const logger = logUtil.getLogger('AmqpMessageBus');
 
@@ -25,10 +24,10 @@ export class AmqpMessageBus implements messageBus.MessageBus {
 
     private decoders: messageBus.MessageDecoders = new messageBus.MessageDecoders();
 
-    private connection: amqp.Connection;
-    private sendChannel: amqp.Channel;
-    private listenChannel: amqp.Channel;
-    private channels: Array<amqp.Channel> = [];
+    private connection: Connection;
+    private sendChannel: Channel;
+    private listenChannel: Channel;
+    private channels: Array<Channel> = [];
     private eventQueues: Map<string, messageBus.MessageQueue> = new Map<string, messageBus.MessageQueue>();
     private commandQueues: Map<string, messageBus.MessageQueue> = new Map<string, messageBus.MessageQueue>();
     private initialised: boolean = false;
@@ -74,9 +73,9 @@ export class AmqpMessageBus implements messageBus.MessageBus {
         logger.info(`[AMQP] AutoConnect enabled`);
 
         // eslint-disable-next-line max-lines-per-function
-        amqp.connect(
+        connect(
             this.host,
-            function (err, conn: amqp.Connection) {
+            function (err, conn: Connection) {
                 if (err || conn === undefined) {
                     logger.warn(`[AMQP] Could not connect to host ${this.host}, do a reconnect`);
                     if (autoReconnect) {
@@ -109,13 +108,13 @@ export class AmqpMessageBus implements messageBus.MessageBus {
                     }.bind(this)
                 );
 
-                conn.createChannel((_err1, channel: amqp.Channel) => {
+                conn.createChannel((_err1, channel: Channel) => {
                     this.sendChannel = channel;
                     this.channels.push(channel);
                     this.done();
                 });
 
-                conn.createChannel((_err1, channel: amqp.Channel) => {
+                conn.createChannel((_err1, channel: Channel) => {
                     this.listenChannel = channel;
                     this.channels.push(channel);
                     this.done();

--- a/src/message-decoder.ts
+++ b/src/message-decoder.ts
@@ -1,3 +1,5 @@
+import { Message } from 'amqplib';
+
 export interface MessageDecoder {
-    decode<T>(message: any): T;
+    decode<T>(message: Message): T;
 }

--- a/src/message-publish-options.ts
+++ b/src/message-publish-options.ts
@@ -1,9 +1,9 @@
 import { MessageEncoding } from './message-encoding';
-import * as amqp from 'amqplib/callback_api';
+import { Channel } from 'amqplib/callback_api';
 
 export interface MessagePublishOptions {
     encoding?: MessageEncoding;
-    sendChannel?: amqp.Channel;
+    sendChannel?: Channel;
     exchangeName?: string;
     exchangeType?: string;
     exchangeDurable?: boolean;

--- a/src/message-subscribe-options.ts
+++ b/src/message-subscribe-options.ts
@@ -1,9 +1,9 @@
 import { MessageDecoding } from './message-decoding';
-import * as amqp from 'amqplib/callback_api';
+import { Channel } from 'amqplib/callback_api';
 
 export interface MessageSubscribeOptions {
     decoding?: MessageDecoding;
-    listenChannel?: amqp.Channel;
+    listenChannel?: Channel;
     exchangeName?: string;
     exchangeType?: string;
     exchangeDurable?: boolean;


### PR DESCRIPTION
- Refactored where types are imported from and how they are referenced
- Added the `@types/amqplib` to the `dependencies` in order to prevent compile errors in projects that imports this library